### PR TITLE
Check spell source for Empowered Evocation feature

### DIFF
--- a/src/dndbeyond/content-scripts/character.js
+++ b/src/dndbeyond/content-scripts/character.js
@@ -1081,7 +1081,8 @@ function handleSpecialSpells(spell_name, damages=[], damage_types=[], {spell_sou
         // Wizard: School of Evocation: Empowered Evocation
         if (character.hasClassFeature("Empowered Evocation") &&
             character.getSetting("empowered-evocation", false) &&
-            spell_level.includes("Evocation")) {
+            spell_level.includes("Evocation")) &&
+            spell_source.includes("Wizard")) {
             damages.push(`${parseInt(character.getAbility("INT").mod)}`);
             damage_types.push("Empowered Evocation");
         }

--- a/src/dndbeyond/content-scripts/character.js
+++ b/src/dndbeyond/content-scripts/character.js
@@ -1081,7 +1081,7 @@ function handleSpecialSpells(spell_name, damages=[], damage_types=[], {spell_sou
         // Wizard: School of Evocation: Empowered Evocation
         if (character.hasClassFeature("Empowered Evocation") &&
             character.getSetting("empowered-evocation", false) &&
-            spell_level.includes("Evocation")) &&
+            spell_level.includes("Evocation") &&
             spell_source.includes("Wizard")) {
             damages.push(`${parseInt(character.getAbility("INT").mod)}`);
             damage_types.push("Empowered Evocation");


### PR DESCRIPTION
Class: Wizard
Subclass: Evocation
Feature: Empowered Evocation (Lvl.10)

Feature reads:
> 
> Empowered Evocation
> Beginning at 10th level, you can add your Intelligence modifier to one damage roll of any **_wizard_** evocation spell you cast.
>  

Issue:
Empowered evocation currently checks that character has feature and spell is the proper school (Evocation), but not source of said spell. 

Resolution:
Additionally check spell_source to contain "Wizard".